### PR TITLE
Switch to kmdf 1.15 (win10+ only) and other small cleanups

### DIFF
--- a/crates/km-sys-bindgen/bindgen.toml
+++ b/crates/km-sys-bindgen/bindgen.toml
@@ -13,6 +13,7 @@ allowed_functions = [
     "SeSinglePrivilegeCheck",
     "RtlConvertLongToLuid",
     "KeDelayExecutionThread",
+    "KeGetCurrentIrql",
 ]
 
 allowed_types = [
@@ -73,7 +74,7 @@ allowed_vars = [
     "DPFLTR_.*",
     "SDDL_DEVOBJ_SYS_ALL_ADM_RWX_WORLD_RW_RES_R",
     "WdfDriverGlobals",
-    "WdfFunctions",
+    "WdfFunctions_01015",
 
     # IRQ levels
     "PASSIVE_LEVEL",

--- a/crates/km-sys/src/generated.rs
+++ b/crates/km-sys/src/generated.rs
@@ -548,6 +548,7 @@ pub type LONG = ::libc::c_long;
 pub type WCHAR = wchar_t;
 pub type PWCH = *mut WCHAR;
 pub type PCHAR = *mut CHAR;
+pub type LPCSTR = *const CHAR;
 pub type PCSTR = *const CHAR;
 pub type UCHAR = ::libc::c_uchar;
 pub type USHORT = ::libc::c_ushort;
@@ -3456,6 +3457,9 @@ pub struct _KEVENT {
 }
 pub type KEVENT = _KEVENT;
 pub type PKEVENT = *mut _KEVENT;
+extern "C" {
+    pub fn KeGetCurrentIrql() -> KIRQL;
+}
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct _KDEVICE_QUEUE {
@@ -5664,7 +5668,7 @@ extern "C" {
 }
 pub type WDFFUNC = ::core::option::Option<unsafe extern "C" fn()>;
 extern "C" {
-    pub static mut WdfFunctions: [WDFFUNC; 0usize];
+    pub static mut WdfFunctions_01015: *const WDFFUNC;
 }
 impl _WDF_TRI_STATE {
     pub const WdfFalse: _WDF_TRI_STATE = _WDF_TRI_STATE(0);
@@ -6053,10 +6057,10 @@ impl _WDFFUNCENUM {
     pub const WdfDeviceSetFailedTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(87);
 }
 impl _WDFFUNCENUM {
-    pub const WdfDeviceStopIdleTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(88);
+    pub const WdfDeviceStopIdleNoTrackTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(88);
 }
 impl _WDFFUNCENUM {
-    pub const WdfDeviceResumeIdleTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(89);
+    pub const WdfDeviceResumeIdleNoTrackTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(89);
 }
 impl _WDFFUNCENUM {
     pub const WdfDeviceGetFileObjectTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(90);
@@ -7327,7 +7331,49 @@ impl _WDFFUNCENUM {
     pub const WdfGetTriageInfoTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(431);
 }
 impl _WDFFUNCENUM {
-    pub const WdfFunctionTableNumEntries: _WDFFUNCENUM = _WDFFUNCENUM(432);
+    pub const WdfDeviceInitSetIoTypeExTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(432);
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceQueryPropertyExTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(433);
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceAllocAndQueryPropertyExTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(
+        434,
+    );
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceAssignPropertyTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(435);
+}
+impl _WDFFUNCENUM {
+    pub const WdfFdoInitQueryPropertyExTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(436);
+}
+impl _WDFFUNCENUM {
+    pub const WdfFdoInitAllocAndQueryPropertyExTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(
+        437,
+    );
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceStopIdleActualTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(438);
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceResumeIdleActualTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(439);
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceGetSelfIoTargetTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(440);
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceInitAllowSelfIoTargetTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(441);
+}
+impl _WDFFUNCENUM {
+    pub const WdfIoTargetSelfAssignDefaultIoQueueTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(
+        442,
+    );
+}
+impl _WDFFUNCENUM {
+    pub const WdfDeviceOpenDevicemapKeyTableIndex: _WDFFUNCENUM = _WDFFUNCENUM(443);
+}
+impl _WDFFUNCENUM {
+    pub const WdfFunctionTableNumEntries: _WDFFUNCENUM = _WDFFUNCENUM(444);
 }
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
@@ -7409,7 +7455,7 @@ pub type PFN_GET_UNIQUE_CONTEXT_TYPE = ::core::option::Option<
 #[derive(Debug, Copy, Clone)]
 pub struct _WDF_OBJECT_CONTEXT_TYPE_INFO {
     pub Size: ULONG,
-    pub ContextName: PCHAR,
+    pub ContextName: LPCSTR,
     pub ContextSize: usize,
     pub UniqueType: PCWDF_OBJECT_CONTEXT_TYPE_INFO,
     pub EvtDriverGetUniqueContextType: PFN_GET_UNIQUE_CONTEXT_TYPE,
@@ -7527,6 +7573,12 @@ impl _WDF_DEVICE_IO_TYPE {
 impl _WDF_DEVICE_IO_TYPE {
     pub const WdfDeviceIoDirect: _WDF_DEVICE_IO_TYPE = _WDF_DEVICE_IO_TYPE(3);
 }
+impl _WDF_DEVICE_IO_TYPE {
+    pub const WdfDeviceIoBufferedOrDirect: _WDF_DEVICE_IO_TYPE = _WDF_DEVICE_IO_TYPE(4);
+}
+impl _WDF_DEVICE_IO_TYPE {
+    pub const WdfDeviceIoMaximum: _WDF_DEVICE_IO_TYPE = _WDF_DEVICE_IO_TYPE(5);
+}
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub struct _WDF_DEVICE_IO_TYPE(pub ::libc::c_int);
@@ -7595,18 +7647,18 @@ pub type PWDF_FILEOBJECT_CONFIG = *mut _WDF_FILEOBJECT_CONFIG;
 pub type PFN_WDFDEVICEINITFREE = ::core::option::Option<
     unsafe extern "C" fn(DriverGlobals: PWDF_DRIVER_GLOBALS, DeviceInit: PWDFDEVICE_INIT),
 >;
-pub type PFN_WDFDEVICEINITSETIOTYPE = ::core::option::Option<
-    unsafe extern "C" fn(
-        DriverGlobals: PWDF_DRIVER_GLOBALS,
-        DeviceInit: PWDFDEVICE_INIT,
-        IoType: WDF_DEVICE_IO_TYPE,
-    ),
->;
 pub type PFN_WDFDEVICEINITSETEXCLUSIVE = ::core::option::Option<
     unsafe extern "C" fn(
         DriverGlobals: PWDF_DRIVER_GLOBALS,
         DeviceInit: PWDFDEVICE_INIT,
         IsExclusive: BOOLEAN,
+    ),
+>;
+pub type PFN_WDFDEVICEINITSETIOTYPE = ::core::option::Option<
+    unsafe extern "C" fn(
+        DriverGlobals: PWDF_DRIVER_GLOBALS,
+        DeviceInit: PWDFDEVICE_INIT,
+        IoType: WDF_DEVICE_IO_TYPE,
     ),
 >;
 pub type PFN_WDFDEVICEINITASSIGNNAME = ::core::option::Option<

--- a/crates/km-sys/src/lib.rs
+++ b/crates/km-sys/src/lib.rs
@@ -17,29 +17,29 @@ const _: () = {
 
     // BufferOverflowFastFailK needs Windows 8+
     // see https://docs.microsoft.com/en-us/windows-hardware/drivers/develop/building-drivers-for-different-versions-of-windows
-    // #[link(name = "BufferOverflowFastFailK")]
-    // extern "C" {}
+    #[link(name = "BufferOverflowFastFailK")]
+    extern "C" {}
 
     // older lib for Vista+
-    #[link(name = "BufferOverflowK")]
-    extern "C" {}
+    // #[link(name = "BufferOverflowK")]
+    // extern "C" {}
 
     #[link(name = "ntoskrnl")]
     extern "C" {}
 
-    // #[link(name = "hal")]
-    // extern "C" {}
-    // #[link(name = "wmilib")]
-    // extern "C" {}
-
-    #[link(name = "wdfldr")]
+    #[link(name = "hal")]
     extern "C" {}
-    #[link(name = "wdfdriverentry")]
+    #[link(name = "wmilib")]
+    extern "C" {}
+
+    #[link(name = "WdfLdr")]
+    extern "C" {}
+    #[link(name = "WdfDriverEntry")]
     extern "C" {}
 
     // #[link(name = "ntstrsafe")]
     // extern "C" {}
 
-    #[link(name = "wdmsec")]
-    extern "C" {}
+    // #[link(name = "wdmsec")]
+    // extern "C" {}
 };

--- a/crates/km/src/assert.rs
+++ b/crates/km/src/assert.rs
@@ -1,5 +1,4 @@
-use core::arch::asm;
-use km_sys::{APC_LEVEL, KIRQL};
+use km_sys::{KeGetCurrentIrql, APC_LEVEL, KIRQL};
 
 /// Asserts that the IRQ level is low enough for the calling function to be paged.
 ///
@@ -10,28 +9,5 @@ use km_sys::{APC_LEVEL, KIRQL};
 #[track_caller]
 pub fn debug_assert_paged_code() {
     // SAFETY: FFI call; no further safety requirements
-    debug_assert!(inlined_ke_get_current_irql() <= APC_LEVEL as KIRQL);
-}
-
-/// Retrieves the current IRQL; see [`KeGetCurrentIrql`][msdn] for more information.
-///
-/// This function is exported by `ntoskrnl.exe`, but apparently the import library `hal.lib` only
-/// exports it in some versions (it does in 10.0.22000, it does not in 10.0.19041). `wdm.h` provides
-/// this as a force-inlined function instead. This reimplements what that function does.
-///
-/// [msdn]: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-kegetcurrentirql
-#[inline(always)]
-fn inlined_ke_get_current_irql() -> KIRQL {
-    let mut irql: u64;
-
-    // SAFETY: this matches the inlined header-only implementation of `KeGetCurrentIrql`
-    // in the wdm.h, for x86_64.
-    unsafe {
-        asm!(
-            "mov {0}, cr8",
-            out(reg) irql,
-            options(nomem, nostack)
-        );
-    }
-    irql as KIRQL
+    debug_assert!(unsafe { KeGetCurrentIrql() } <= APC_LEVEL as KIRQL);
 }

--- a/crates/km/src/wdf/ffi.rs
+++ b/crates/km/src/wdf/ffi.rs
@@ -43,8 +43,7 @@ macro_rules! wdf_function {
             // we're accessing here.
             let fp: *const <$fp_ptr as Inner>::Inner = unsafe {
                 core::mem::transmute(
-                    ::km_sys::WdfFunctions
-                        .as_ptr()
+                    ::km_sys::WdfFunctions_01015
                         .offset($index.0 as isize),
                 )
             };


### PR DESCRIPTION
- use exported KeGetCurrentIrql now
- align linking with what windows-drivers-rs does